### PR TITLE
ensured only lower case words are looked up

### DIFF
--- a/VaderSharp/VaderSharp/SentimentUtils.cs
+++ b/VaderSharp/VaderSharp/SentimentUtils.cs
@@ -202,7 +202,7 @@ namespace VaderSharp
             if (!BoosterDict.ContainsKey(wordLower))
                 return 0.0;
 
-            double scalar = BoosterDict[word];
+            double scalar = BoosterDict[wordLower];
             if (valence < 0)
                 scalar *= -1;
 


### PR DESCRIPTION
Would throw when upper or mixed case words are checked in BoosterDict in ScalarIncDec