### PR TITLE
Moved constant to begining of && in if

### DIFF
--- a/VaderSharp/VaderSharp/SentimentIntensityAnalyzer.cs
+++ b/VaderSharp/VaderSharp/SentimentIntensityAnalyzer.cs
@@ -73,7 +73,7 @@ namespace VaderSharp
             bool isCapDiff = sentiText.IsCapDifferential;
             IList<string> wordsAndEmoticons = sentiText.WordsAndEmoticons;
             valence = Lexicon[itemLowerCase];
-            if (item.IsUpper() && isCapDiff)
+            if (isCapDiff && item.IsUpper())
             {
                 if (valence > 0)
                 {


### PR DESCRIPTION
Why run a string function when it may not be necessary