### PR TITLE
Fix to support other languages

### DIFF
--- a/VaderSharp/VaderSharp/SentimentIntensityAnalyzer.cs
+++ b/VaderSharp/VaderSharp/SentimentIntensityAnalyzer.cs
@@ -16,26 +16,47 @@ namespace VaderSharp
         private const double QuesIncrSmall = 0.18;
         private const double QuesIncrLarge = 0.96;
 
-        private static Dictionary<string, double> Lexicon { get; }
-        private static string[] LexiconFullFile { get; }
+        private Dictionary<string, double> Lexicon = null;
+        private string[] LexiconFullFile = null;
 
-        static SentimentIntensityAnalyzer()
+        public SentimentIntensityAnalyzer()
         {
-            Assembly assembly;
+            if (Lexicon == null)
+            {
+                Assembly assembly;
 #if NET_35
             assembly = typeof(SentimentIntensityAnalyzer).Assembly;
 #else
-            assembly = typeof(SentimentIntensityAnalyzer).GetTypeInfo().Assembly;
+                assembly = typeof(SentimentIntensityAnalyzer).GetTypeInfo().Assembly;
 #endif
-            using (var stream = assembly.GetManifestResourceStream("VaderSharp.vader_lexicon.txt"))
-            using(var reader = new StreamReader(stream))
-            {
-                LexiconFullFile = reader.ReadToEnd().Split('\n');
-                Lexicon = MakeLexDic();
+                using (var stream = assembly.GetManifestResourceStream("VaderSharp.vader_lexicon.txt"))
+                using (var reader = new StreamReader(stream))
+                {
+                    LexiconFullFile = reader.ReadToEnd().Split('\n');
+                    Lexicon = MakeLexDic();
+                }
             }
         }
 
-        private static Dictionary<string,double> MakeLexDic()
+        public SentimentIntensityAnalyzer(string fileName)
+        {
+            if (Lexicon == null)
+            {
+                if (!File.Exists(fileName))
+                {
+                    throw new Exception("Lexicon file not found");
+                }
+
+                using (var stream = new FileStream(fileName, FileMode.Open))
+                using (var reader = new StreamReader(stream))
+                {
+                    LexiconFullFile = reader.ReadToEnd().Split('\n');
+                    Lexicon = MakeLexDic();
+                }
+            }
+        }
+
+        private Dictionary<string,double> MakeLexDic()
         {
             var dic = new Dictionary<string, double>();
             foreach (var line in LexiconFullFile)

--- a/VaderSharp/VaderSharp/SentimentIntensityAnalyzer.cs
+++ b/VaderSharp/VaderSharp/SentimentIntensityAnalyzer.cs
@@ -62,7 +62,7 @@ namespace VaderSharp
             foreach (var line in LexiconFullFile)
             {
                 var lineArray = line.Trim().Split('\t');
-                dic.Add(lineArray[0], Double.Parse(lineArray[1]));
+                dic.Add(lineArray[0], Double.Parse(lineArray[1], System.Globalization.CultureInfo.InvariantCulture));
             }
             return dic;
         }


### PR DESCRIPTION
The current version has major problems for supporting non-english users.
First, it uses the current system culture while trying to parse decimals with dot, which causes an exception to be thrown when running Vader in a OS with Portuguese language (probably will fail in French and other languages).

Second, it uses an hardcoded lexicon file which is great for English but this library should also be able to analyze texts from other languages. For that, I added an second constructor that takes a file name as argument, to let the programmer load a custom lexicon file.

Finally, due that previous change, I removed the static constructor and static lexicon dictionary. 
The programmer can keep an instance of an SentimentIntensityAnalyzer and reuse it as necessary. And now with the addition of custom lexicon files, we might need to have multiple lexicon files loaded, so the dictionary can no longer be static.