### PR TITLE
Fixed handling of capitalized words for negation check

### DIFF
--- a/VaderSharp/VaderSharp/SentimentIntensityAnalyzer.cs
+++ b/VaderSharp/VaderSharp/SentimentIntensityAnalyzer.cs
@@ -175,7 +175,7 @@ namespace VaderSharp
         {
             if (startI == 0)
             {
-                if (SentimentUtils.Negated(new List<string> {wordsAndEmoticons[i - 1]}))
+                if (SentimentUtils.Negated(new List<string> {wordsAndEmoticons[i - 1].ToLower()}))
                     valence = valence * SentimentUtils.NScalar;
             }
             if (startI == 1)
@@ -185,7 +185,7 @@ namespace VaderSharp
                 {
                     valence = valence * 1.5;
                 }
-                else if (SentimentUtils.Negated(new List<string> {wordsAndEmoticons[i - (startI + 1)]}))
+                else if (SentimentUtils.Negated(new List<string> {wordsAndEmoticons[i - (startI + 1)].ToLower()}))
                 {
                     valence = valence * SentimentUtils.NScalar;
                 }
@@ -198,7 +198,7 @@ namespace VaderSharp
                 {
                     valence = valence * 1.25;
                 }
-                else if (SentimentUtils.Negated(new List<string> { wordsAndEmoticons[i - (startI + 1)] }))
+                else if (SentimentUtils.Negated(new List<string> { wordsAndEmoticons[i - (startI + 1)].ToLower() }))
                 {
                     valence = valence * SentimentUtils.NScalar;
                 }


### PR DESCRIPTION
This solves the "_Not bad at all_" problem case, see [issue](https://github.com/codingupastorm/vadersharp/issues/18)

The issue is with NeverCheck() calling SentimentUtils.Negated with the list of words to be compared to the list of negations. The words in the negations dictionary are all lowercase, so to get a match we need to lower the words we pass to it.